### PR TITLE
chore: centralize debug logging

### DIFF
--- a/src/ServerScriptService/Modules/DebugLogger.lua
+++ b/src/ServerScriptService/Modules/DebugLogger.lua
@@ -1,0 +1,25 @@
+-- DebugLogger.lua
+-- Shared debug logging utility
+
+local function new(prefix, enabled)
+    enabled = enabled ~= false
+
+    local function log(...)
+        if enabled then
+            print("[" .. prefix .. "]", ...)
+        end
+    end
+
+    local function warnf(...)
+        if enabled then
+            warn("[" .. prefix .. "]", ...)
+        end
+    end
+
+    return log, warnf
+end
+
+return {
+    new = new,
+}
+

--- a/src/ServerScriptService/Server/InventoryServerHandler.server.lua
+++ b/src/ServerScriptService/Server/InventoryServerHandler.server.lua
@@ -13,6 +13,7 @@ local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local ItemData       = require(ReplicatedStorage.Modules:WaitForChild("ItemDataModule"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local ProfileSyncService = require(Modules:WaitForChild("ProfileSyncService"))
+local DebugLogger = require(Modules:WaitForChild("DebugLogger"))
 
 --// Remotes
 local InventoryFolder = ReplicatedStorage.Remotes:WaitForChild("Inventory")
@@ -20,9 +21,7 @@ local getInventoryFunction = InventoryFolder:WaitForChild("GetInventoryData")
 local addItemEvent        = InventoryFolder:WaitForChild("AddItemRequest")
 local removeItemEvent     = InventoryFolder:WaitForChild("RemoveItemRequest")
 
-local DEBUG = true
-local function log(...) if DEBUG then print("[InventoryServerHandler]", ...) end end
-local function warnf(...) if DEBUG then warn("[InventoryServerHandler]", ...) end end
+local log, warnf = DebugLogger.new("InventoryServerHandler", true)
 
 -- GetInventoryData: Inventory als Array an Client
 getInventoryFunction.OnServerInvoke = function(player)

--- a/src/ServerScriptService/Server/QuestServerHandler.server.lua
+++ b/src/ServerScriptService/Server/QuestServerHandler.server.lua
@@ -6,16 +6,13 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
---// Modules
 local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local QuestData = require(ReplicatedStorage.Modules:WaitForChild("QuestDataModule"))
 local ProfileSyncService = require(Modules:WaitForChild("ProfileSyncService"))
+local DebugLogger = require(Modules:WaitForChild("DebugLogger"))
 
---// Debug
-local DEBUG = true
-local function log(...)   if DEBUG then print("[QuestServerHandler]", ...) end end
-local function warnf(...) if DEBUG then warn("[QuestServerHandler]", ...) end end
+local log, warnf = DebugLogger.new("QuestServerHandler", true)
 
 --// Remotes
 local claimQuestEvent     = ReplicatedStorage.Remotes.Quests:WaitForChild("ClaimQuest")


### PR DESCRIPTION
## Summary
- add DebugLogger module for reusable logging
- use DebugLogger in QuestServerHandler and InventoryServerHandler

## Testing
- `rojo build default.project.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971a0c6638833389494689a5e11ca2