### PR TITLE
Fix tooltip attachment in teleport GUI

### DIFF
--- a/src/StarterGui/GuiScripts/MainTeleportScript.client.lua
+++ b/src/StarterGui/GuiScripts/MainTeleportScript.client.lua
@@ -145,9 +145,8 @@ for i = 1, 6 do
 					label.Text = reward.amount .. "x " .. (reward.id or reward.type)
 					label.Parent = entry
 
-					TooltipModule:Attach(entry, function()
-						return rewardTooltip(reward)
-					end)
+                                       -- Set tooltip text using TooltipModule so TooltipController can display it
+                                       TooltipModule.AttachTooltip(entry, { text = rewardTooltip(reward) })
 
 					entry.Parent = rewardList
 				end


### PR DESCRIPTION
## Summary
- use `TooltipModule.AttachTooltip` to set reward tooltips in teleport GUI

## Testing
- `curl -L -o rojo.tar.gz https://github.com/rojo-rbx/rojo/releases/download/v7.5.1/rojo-7.5.1-linux-x86_64.tar.gz` *(failed: CONNECT tunnel failed, response 403)*
- `rojo build default.project.json -o out.rbxm` *(command not found: rojo)*

------
https://chatgpt.com/codex/tasks/task_e_689724a783088333b9bf5225c3de7c47