### PR TITLE
Fix reward icons in teleport GUI

### DIFF
--- a/src/StarterGui/GuiScripts/MainTeleportScript.client.lua
+++ b/src/StarterGui/GuiScripts/MainTeleportScript.client.lua
@@ -10,6 +10,7 @@ local GuiResolver    = require(ReplicatedStorage.Modules.GuiResolver)
 local PanelManager   = require(ReplicatedStorage.Modules.PanelManager)
 local PanelDebounce  = require(ReplicatedStorage.Modules.PanelDebounce)
 local TooltipModule  = require(ReplicatedStorage.Modules.TooltipModule)
+local ItemData       = require(ReplicatedStorage.Modules.ItemDataModule)
 
 --// Remotes
 local teleportRemote = ReplicatedStorage.Remotes.Teleport:WaitForChild("TeleportStageRequest")
@@ -49,13 +50,23 @@ panel:GetPropertyChangedSignal("Visible"):Connect(function()
 	end
 end)
 
--- Tooltip aus Reward-Daten erzeugen
 local function rewardTooltip(reward)
-	if reward.id then
-		return "[b]" .. reward.id .. "\\n[img:12345678] x" .. reward.amount
-	else
-		return "[b]" .. reward.type .. "\\n+" .. reward.amount
-	end
+        local meta
+        if reward.id then
+                meta = ItemData[reward.id]
+        elseif reward.type then
+                meta = ItemData[reward.type]
+        end
+
+        local name = meta and meta.displayName or (reward.id or reward.type)
+        local iconId = meta and meta.iconId
+        local rawId = iconId and iconId:match("rbxassetid://(%d+)") or "12345678"
+
+        if reward.id then
+                return "[b]" .. name .. "\\n[img:" .. rawId .. "] x" .. reward.amount
+        else
+                return "[b]" .. name .. "\\n[img:" .. rawId .. "] +" .. reward.amount
+        end
 end
 
 -- Welt-Auswahl
@@ -120,38 +131,45 @@ for i = 1, 6 do
 			-- Rewards anzeigen
 			local rewardList = clone:FindFirstChild("RewardList")
 			if rewardList then
-				for _, reward in ipairs(stageData.Rewards) do
-					local entry = Instance.new("Frame")
-					entry.Name = "RewardEntry"
-					entry.Size = UDim2.new(1, 0, 0, 28)
-					entry.BackgroundTransparency = 1
-					entry.Active = true
+                                for _, reward in ipairs(stageData.Rewards) do
+                                        local entry = Instance.new("Frame")
+                                        entry.Name = "RewardEntry"
+                                        entry.Size = UDim2.new(1, 0, 0, 28)
+                                        entry.BackgroundTransparency = 1
+                                        entry.Active = true
 
-					local icon = Instance.new("ImageLabel")
-					icon.Size = UDim2.new(0, 24, 0, 24)
-					icon.Position = UDim2.new(0, 0, 0, 2)
-					icon.BackgroundTransparency = 1
-					icon.Image = reward.image or "rbxassetid://12345678"
-					icon.Parent = entry
+                                        local meta
+                                        if reward.id then
+                                                meta = ItemData[reward.id]
+                                        elseif reward.type then
+                                                meta = ItemData[reward.type]
+                                        end
 
-					local label = Instance.new("TextLabel")
-					label.Size = UDim2.new(1, -30, 1, 0)
-					label.Position = UDim2.new(0, 30, 0, 0)
-					label.BackgroundTransparency = 1
-					label.Font = Enum.Font.Gotham
-					label.TextSize = 14
-					label.TextColor3 = Color3.fromRGB(220, 220, 220)
-					label.TextXAlignment = Enum.TextXAlignment.Left
-					label.Text = reward.amount .. "x " .. (reward.id or reward.type)
-					label.Parent = entry
+                                        local icon = Instance.new("ImageLabel")
+                                        icon.Size = UDim2.new(0, 24, 0, 24)
+                                        icon.Position = UDim2.new(0, 0, 0, 2)
+                                        icon.BackgroundTransparency = 1
+                                        icon.Image = reward.image or (meta and meta.iconId) or "rbxassetid://12345678"
+                                        icon.Parent = entry
 
-					TooltipModule:Attach(entry, function()
-						return rewardTooltip(reward)
-					end)
+                                        local label = Instance.new("TextLabel")
+                                        label.Size = UDim2.new(1, -30, 1, 0)
+                                        label.Position = UDim2.new(0, 30, 0, 0)
+                                        label.BackgroundTransparency = 1
+                                        label.Font = Enum.Font.Gotham
+                                        label.TextSize = 14
+                                        label.TextColor3 = Color3.fromRGB(220, 220, 220)
+                                        label.TextXAlignment = Enum.TextXAlignment.Left
+                                        local displayName = meta and meta.displayName or (reward.id or reward.type)
+                                        label.Text = reward.amount .. "x " .. displayName
+                                        label.Parent = entry
 
-					entry.Parent = rewardList
-				end
-			end
+                                       -- Set tooltip text using TooltipModule so TooltipController can display it
+                                       TooltipModule.AttachTooltip(entry, { text = rewardTooltip(reward) })
+
+                                        entry.Parent = rewardList
+                                end
+                        end
 
 			local tpButton = clone:FindFirstChild("TeleportButton")
 			if tpButton and tpButton:IsA("ImageButton") then


### PR DESCRIPTION
## Summary
- use `TooltipModule.AttachTooltip` to set reward tooltips in teleport GUI
- load reward icons and names from ItemDataModule instead of placeholder images

## Testing
- `curl -L -o rojo.tar.gz https://github.com/rojo-rbx/rojo/releases/download/v7.5.1/rojo-7.5.1-linux-x86_64.tar.gz` *(failed: CONNECT tunnel failed, response 403)*
- `tar -xzf rojo.tar.gz` *(failed: No such file or directory)*
- `rojo build default.project.json -o out.rbxm` *(failed: command not found: rojo)*

------
https://chatgpt.com/codex/tasks/task_e_689724a783088333b9bf5225c3de7c47