### PR TITLE
refactor: split profile wrapper into services

### DIFF
--- a/src/ServerScriptService/Debug/QuestDebugScript.server.lua
+++ b/src/ServerScriptService/Debug/QuestDebugScript.server.lua
@@ -7,7 +7,7 @@ local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 
 --// Module
-local ProfileWrapper = require(game.ServerScriptService.Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(game.ServerScriptService.Modules:WaitForChild("ProfileService"))
 local QuestData = require(game.ReplicatedStorage.Modules:WaitForChild("QuestDataModule"))
 
 --// Einstellungen
@@ -19,14 +19,14 @@ local testPlayerName = "RDBEmpire"
 --// Funktion: Quest erhöhen
 local function incrementQuest()
 	local player = Players:FindFirstChild(testPlayerName)
-	if not player or not ProfileWrapper:IsLoaded(player) then
-		warn("❌ Kein Spieler oder Profil nicht geladen")
-		return
-	end
+        if not player or not ProfileService:IsLoaded(player) then
+                warn("❌ Kein Spieler oder Profil nicht geladen")
+                return
+        end
 
-	ProfileWrapper:IncrementQuest(player, questType, questId, addAmount)
+        ProfileService:IncrementQuest(player, questType, questId, addAmount)
 
-	local progress = ProfileWrapper:GetQuestProgress(player, questType)
+        local progress = ProfileService:GetQuestProgress(player, questType)
 	local questList = QuestData[questType]
 	local questData = nil
 

--- a/src/ServerScriptService/Modules/ProfileReadyService.lua
+++ b/src/ServerScriptService/Modules/ProfileReadyService.lua
@@ -15,7 +15,7 @@ local ProfileReadyRE = RemotesRoot:FindFirstChild("ProfileReady") :: RemoteEvent
 
 -- Projekt-Module
 local ModulesRoot = ServerScriptService:WaitForChild("Modules")
-local ProfileStoreWrapper = require(ModulesRoot:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(ModulesRoot:WaitForChild("ProfileService"))
 
 -- MatchState liegt NUR in Story-Maps unter ServerScriptService.TowerDefense (optional)
 local TowerDefenseFolder = ServerScriptService:FindFirstChild("TowerDefense")
@@ -182,7 +182,7 @@ Players.PlayerAdded:Connect(function(player)
 		local profile
 		local t0 = os.clock()
 		repeat
-			profile = ProfileStoreWrapper:GetProfile(player)
+                        profile = ProfileService:GetProfile(player)
 			if profile then break end
 			task.wait(0.1)
 		until (os.clock() - t0) > 15.0 or not player.Parent
@@ -201,12 +201,12 @@ end)
 
 local AwaitProfileRF_Typed: RemoteFunction = AwaitProfileRF
 AwaitProfileRF_Typed.OnServerInvoke = function(player: Player)
-	local profile = ProfileStoreWrapper:GetProfile(player)
+    local profile = ProfileService:GetProfile(player)
 	if not profile then
 		local t0 = os.clock()
 		repeat
 			task.wait(0.1)
-			profile = ProfileStoreWrapper:GetProfile(player)
+                    profile = ProfileService:GetProfile(player)
 			if profile then break end
 		until (os.clock() - t0) > 15.0
 		if not profile then

--- a/src/ServerScriptService/Modules/ProfileService.lua
+++ b/src/ServerScriptService/Modules/ProfileService.lua
@@ -1,4 +1,4 @@
--- ProfileStoreWrapper.lua
+-- ProfileService.lua
 -- Typ: ModuleScript
 
 --// Services
@@ -930,16 +930,18 @@ function ProfileWrapper:Sync(player: Player, key: string)
 end
 
 task.spawn(function()
-	while true do
-		task.wait(AUTOSAVE_INTERVAL)
-		for userId, profile in pairs(activeProfiles) do
-			if profile:IsActive() then
-				profile:Save()
-				local player = Players:GetPlayerByUserId(userId)
-				if player then log("AutoSave für", player.Name) end
-			end
-		end
-	end
+        while true do
+                task.wait(AUTOSAVE_INTERVAL)
+                for userId, profile in pairs(activeProfiles) do
+                        if profile:IsActive() then
+                                profile:Save()
+                                local player = Players:GetPlayerByUserId(userId)
+                                if player then log("AutoSave für", player.Name) end
+                        end
+                end
+        end
 end)
+
+ProfileWrapper.SystemsToWaitFor = systemsToWaitFor
 
 return ProfileWrapper

--- a/src/ServerScriptService/Modules/ProgressTrackerService.lua
+++ b/src/ServerScriptService/Modules/ProgressTrackerService.lua
@@ -5,7 +5,7 @@
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 
 --// Debug
 local DEBUG = true
@@ -21,7 +21,7 @@ local ProgressTrackerService = {}
 
 -- Inkrementiert Fortschritt (z. B. für Kills, Summons)
 function ProgressTrackerService:Increment(player, questType, questId, amount)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("Progress-Increment abgelehnt (Profil nicht geladen) für", player and player.Name)
 		return
 	end
@@ -38,7 +38,7 @@ function ProgressTrackerService:Increment(player, questType, questId, amount)
 		return
 	end
 
-	ProfileWrapper:IncrementQuest(player, questType, questId, amount)
+        ProfileService:IncrementQuest(player, questType, questId, amount)
 	log("Progress-Increment:", questType, questId, "+", amount, "bei", player.Name)
 end
 

--- a/src/ServerScriptService/Modules/RewardService.lua
+++ b/src/ServerScriptService/Modules/RewardService.lua
@@ -1,0 +1,45 @@
+-- RewardService.lua
+-- Wrapper around ProfileService for reward and EXP related functions
+
+local Modules = script.Parent
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+
+local RewardService = {}
+
+function RewardService.AddPlayerEXP(...)
+    return ProfileService:AddPlayerEXP(...)
+end
+
+function RewardService.AddEclipsium(...)
+    return ProfileService:AddEclipsium(...)
+end
+
+function RewardService.AddTDEclipsium(...)
+    return ProfileService:AddTDEclipsium(...)
+end
+
+function RewardService.AddGems(...)
+    return ProfileService:AddGems(...)
+end
+
+function RewardService.RemoveEclipsium(...)
+    return ProfileService:RemoveEclipsium(...)
+end
+
+function RewardService.RemoveTDEclipsium(...)
+    return ProfileService:RemoveTDEclipsium(...)
+end
+
+function RewardService.RemoveGems(...)
+    return ProfileService:RemoveGems(...)
+end
+
+function RewardService.AddBattlepassEXP(...)
+    return ProfileService:AddBattlepassEXP(...)
+end
+
+function RewardService.GrantRewards(...)
+    return ProfileService:GrantRewards(...)
+end
+
+return RewardService

--- a/src/ServerScriptService/Modules/StageTeleportService.lua
+++ b/src/ServerScriptService/Modules/StageTeleportService.lua
@@ -9,7 +9,7 @@ local ServerScriptService = game:GetService("ServerScriptService")
 --// Module
 local MapData = require(ReplicatedStorage.Modules.MapDataModule)
 local MapDataUtils = require(ReplicatedStorage.Modules.MapDataUtils)
-local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrapper)
+local ProfileService = require(ServerScriptService.Modules.ProfileService)
 
 --// Debug Helper
 local DEBUG = true
@@ -43,7 +43,7 @@ function StageTeleportService.TeleportToStage(player: Player, worldName: string,
 
 	-- Stage im Profil speichern
 	if worldName ~= "Lobby" then
-		local success = ProfileStoreWrapper:SetSelectedStage(player, worldName, stageId)
+                local success = ProfileService:SetSelectedStage(player, worldName, stageId)
 		if not success then
 			warn("[StageTeleportService] ❌ Konnte SelectedStage nicht speichern")
 			return false

--- a/src/ServerScriptService/Modules/SystemReadyService.lua
+++ b/src/ServerScriptService/Modules/SystemReadyService.lua
@@ -1,0 +1,17 @@
+-- SystemReadyService.lua
+-- Wrapper around ProfileService for system ready tracking
+
+local Modules = script.Parent
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+
+local SystemReadyService = {}
+
+function SystemReadyService.MarkSystemReady(...)
+    return ProfileService:MarkSystemReady(...)
+end
+
+function SystemReadyService.GetSystems()
+    return ProfileService.SystemsToWaitFor
+end
+
+return SystemReadyService

--- a/src/ServerScriptService/Server/BattlepassServerHandler.server.lua
+++ b/src/ServerScriptService/Server/BattlepassServerHandler.server.lua
@@ -7,7 +7,8 @@ local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+local RewardService = require(Modules:WaitForChild("RewardService"))
 local BattlepassInfoProvider = require(ReplicatedStorage.Modules:WaitForChild("BattlepassInfoProvider"))
 BattlepassInfoProvider.Regenerate()
 
@@ -24,9 +25,9 @@ local function warnf(...) if DEBUG then warn("[BattlepassServerHandler]", ...) e
 
 --// Battlepass Info abrufen
 GetBattlepassInfo.OnServerInvoke = function(player)
-	if not ProfileWrapper:IsLoaded(player) then return nil end
+        if not ProfileService:IsLoaded(player) then return nil end
 
-	local playerBP = ProfileWrapper:GetBattlepass(player)
+        local playerBP = ProfileService:GetBattlepass(player)
 	local levelData = {}
 
 	for i = 1, BattlepassInfoProvider.GetMaxLevel() do
@@ -61,10 +62,10 @@ GetBattlepassInfo.OnServerInvoke = function(player)
 end
 
 ClaimFree.OnServerEvent:Connect(function(player, level)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(level) ~= "number" then return end
 
-	local playerBP = ProfileWrapper:GetBattlepass(player)
+        local playerBP = ProfileService:GetBattlepass(player)
 	local claimed = playerBP.Claimed or {}
 	local claimKey = tostring(level) .. "_free"
 
@@ -78,11 +79,11 @@ ClaimFree.OnServerEvent:Connect(function(player, level)
 		return
 	end
 
-	ProfileWrapper:GrantRewards(player, { entry.free }, true)
-	ProfileWrapper:ClaimBattlepassReward(player, level, "free")
+        RewardService.GrantRewards(player, { entry.free }, true)
+        ProfileService:ClaimBattlepassReward(player, level, "free")
 
 	-- 🔥 Hier Battlepass-Daten syncen:
-	local updatedBP = ProfileWrapper:GetBattlepass(player)
+        local updatedBP = ProfileService:GetBattlepass(player)
 	ReplicatedStorage.Remotes.Profile.ProfileChanged:FireClient(player, "Battlepass", updatedBP)
 
 	log(player.Name, "hat FREE Battlepass-Level", level, "beansprucht")
@@ -90,10 +91,10 @@ end)
 
 --// Premium Belohnung beanspruchen
 ClaimPremium.OnServerEvent:Connect(function(player, level)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(level) ~= "number" then return end
 
-	local playerBP = ProfileWrapper:GetBattlepass(player)
+        local playerBP = ProfileService:GetBattlepass(player)
 	if not playerBP.HasPremium then
 		log(player.Name, "hat keinen Premium-Pass – Zugriff verweigert")
 		return
@@ -118,11 +119,11 @@ ClaimPremium.OnServerEvent:Connect(function(player, level)
 		return
 	end
 
-	ProfileWrapper:GrantRewards(player, { entry.premium }, true)
-	ProfileWrapper:ClaimBattlepassReward(player, level, "premium")
+        RewardService.GrantRewards(player, { entry.premium }, true)
+        ProfileService:ClaimBattlepassReward(player, level, "premium")
 
 	-- 🔥 Hier Battlepass-Daten syncen:
-	local updatedBP = ProfileWrapper:GetBattlepass(player)
+        local updatedBP = ProfileService:GetBattlepass(player)
 	ReplicatedStorage.Remotes.Profile.ProfileChanged:FireClient(player, "Battlepass", updatedBP)
 
 	log(player.Name, "hat PREMIUM Battlepass-Level", level, "beansprucht")

--- a/src/ServerScriptService/Server/CodeRedeemHandler.server.lua
+++ b/src/ServerScriptService/Server/CodeRedeemHandler.server.lua
@@ -7,7 +7,8 @@ local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+local RewardService = require(Modules:WaitForChild("RewardService"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local CodesDataModule = require(ReplicatedStorage.Modules:WaitForChild("CodeDataModule"))
 
@@ -21,7 +22,7 @@ local redeemCodeEvent = ReplicatedStorage.Remotes.Codes:WaitForChild("RedeemCode
 local codeResultEvent = ReplicatedStorage.Remotes.Codes:WaitForChild("CodeResultEvent")
 
 redeemCodeEvent.OnServerEvent:Connect(function(player, codeStr)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("RedeemCode abgelehnt (Profil nicht geladen) für", player and player.Name)
 		codeResultEvent:FireClient(player, false, "PROFILE_NOT_LOADED")
 		return
@@ -46,7 +47,7 @@ redeemCodeEvent.OnServerEvent:Connect(function(player, codeStr)
 	end
 
 	-- Profil holen
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then
 		warnf("Kein Profil gefunden bei", player.Name)
 		codeResultEvent:FireClient(player, false, "PROFILE_NOT_FOUND")
@@ -70,7 +71,7 @@ redeemCodeEvent.OnServerEvent:Connect(function(player, codeStr)
 
 	-- Rewards vergeben über ProfileWrapper
 	if codeInfo.Rewards then
-		ProfileWrapper:GrantRewards(player, codeInfo.Rewards)
+                RewardService.GrantRewards(player, codeInfo.Rewards)
 		log("Rewards vergeben für Code:", codeKey, "an", player.Name)
 	else
 		warnf("Kein Rewards-Feld im Code:", codeKey)

--- a/src/ServerScriptService/Server/DebugServerHandler.server.lua
+++ b/src/ServerScriptService/Server/DebugServerHandler.server.lua
@@ -4,7 +4,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 local Players = game:GetService("Players")
 
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 local debugFolder = ReplicatedStorage:WaitForChild("Remotes"):FindFirstChild("Debug")
 
 if not debugFolder then
@@ -18,7 +18,7 @@ remote.Name = "IncrementQuest"
 remote.Parent = debugFolder
 
 remote.OnServerEvent:Connect(function(player, questType, questId, amount)
-	if ProfileWrapper:IsLoaded(player) then
-		ProfileWrapper:IncrementQuest(player, questType, questId, amount, true)
-	end
+        if ProfileService:IsLoaded(player) then
+                ProfileService:IncrementQuest(player, questType, questId, amount, true)
+        end
 end)

--- a/src/ServerScriptService/Server/InventoryServerHandler.server.lua
+++ b/src/ServerScriptService/Server/InventoryServerHandler.server.lua
@@ -9,7 +9,7 @@ local Modules           = ServerScriptService:WaitForChild("Modules")
 local Players = game:GetService("Players")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 local ItemData       = require(ReplicatedStorage.Modules:WaitForChild("ItemDataModule"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local ProfileSyncService = require(Modules:WaitForChild("ProfileSyncService"))
@@ -25,12 +25,12 @@ local log, warnf = DebugLogger.new("InventoryServerHandler", true)
 
 -- GetInventoryData: Inventory als Array an Client
 getInventoryFunction.OnServerInvoke = function(player)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warn("❌ [GetInventoryData] Profil nicht geladen für", player)
 		return {}
 	end
 
-	local inventory = ProfileWrapper:GetInventory(player)
+        local inventory = ProfileService:GetInventory(player)
 	if typeof(inventory) ~= "table" then
 		warn("❌ [GetInventoryData] Ungültiges Inventory für", player, "Typ:", typeof(inventory))
 		return {}
@@ -60,7 +60,7 @@ end
 
 -- AddItemRequest: Item hinzufügen
 addItemEvent.OnServerEvent:Connect(function(player, itemId, amount)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(itemId) ~= "string" or itemId == "" then return end
 	if type(amount) ~= "number" or amount <= 0 or amount > 999 then return end
 	if not ItemData[itemId] then return end
@@ -72,13 +72,13 @@ addItemEvent.OnServerEvent:Connect(function(player, itemId, amount)
 		return
 	end
 
-	ProfileWrapper:AddItemTyped(player, category, itemId, amount)
+        ProfileService:AddItemTyped(player, category, itemId, amount)
 	log("Item hinzugefügt:", itemId, "x", amount, "Typ:", category, "→", player.Name)
 end)
 
 -- RemoveItemRequest: Item entfernen
 removeItemEvent.OnServerEvent:Connect(function(player, itemId, amount)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(itemId) ~= "string" or itemId == "" then return end
 	if type(amount) ~= "number" or amount <= 0 or amount > 999 then return end
 	if not ItemData[itemId] then return end
@@ -90,14 +90,14 @@ removeItemEvent.OnServerEvent:Connect(function(player, itemId, amount)
 		return
 	end
 
-	local success = ProfileWrapper:RemoveItemTyped(player, category, itemId, amount)
+        local success = ProfileService:RemoveItemTyped(player, category, itemId, amount)
 	if success then
 		log("Item entfernt:", itemId, "x", amount, "Typ:", category, "←", player.Name)
 	else
 		warnf("❌ Entfernen fehlgeschlagen:", itemId, "bei", player.Name)
 	end
 
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if profile then
 		ProfileSyncService:Send(player, "Inventory", profile.Data.Inventory)
 	end

--- a/src/ServerScriptService/Server/QuestServerHandler.server.lua
+++ b/src/ServerScriptService/Server/QuestServerHandler.server.lua
@@ -6,7 +6,8 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+local RewardService = require(Modules:WaitForChild("RewardService"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local QuestData = require(ReplicatedStorage.Modules:WaitForChild("QuestDataModule"))
 local ProfileSyncService = require(Modules:WaitForChild("ProfileSyncService"))
@@ -29,7 +30,7 @@ end)(), ", "))
 
 --// Einzelne Quest claimen
 claimQuestEvent.OnServerEvent:Connect(function(player, questData)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(questData) ~= "table" then return end
 
 	local questType = questData.tab
@@ -38,7 +39,7 @@ claimQuestEvent.OnServerEvent:Connect(function(player, questData)
 	if type(questType) ~= "string" or type(questId) ~= "string" then return end
 	if ServerDebounce:Block(player, "ClaimQuest_" .. questId, 1.5) then return end
 
-	local progress = ProfileWrapper:GetQuestProgress(player, questType)
+        local progress = ProfileService:GetQuestProgress(player, questType)
 	if progress[questId .. "_claimed"] then return end
 
 	local questList = QuestData[questType]
@@ -52,10 +53,10 @@ claimQuestEvent.OnServerEvent:Connect(function(player, questData)
 
 	if (progress[questId] or 0) < (quest.goal or 1) then return end
 
-	ProfileWrapper:GrantRewards(player, quest.rewards or {}, true)
-	ProfileWrapper:ClaimQuest(player, questType, questId)
+        RewardService.GrantRewards(player, quest.rewards or {}, true)
+        ProfileService:ClaimQuest(player, questType, questId)
 
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if profile then
 		ProfileSyncService:Send(player, "QuestProgress", profile.Data.QuestProgress)
 	end
@@ -66,14 +67,14 @@ end)
 
 --// Alle Quests eines Typs claimen
 claimAllQuestsEvent.OnServerEvent:Connect(function(player, data)
-	if not ProfileWrapper:IsLoaded(player) then return end
+        if not ProfileService:IsLoaded(player) then return end
 	if type(data) ~= "table" or type(data.tab) ~= "string" then return end
 
 	local questType = data.tab
 	if ServerDebounce:Block(player, "ClaimAllQuests_" .. questType, 2.0) then return end
 
 	local claimedCount = 0
-	local progress = ProfileWrapper:GetQuestProgress(player, questType)
+        local progress = ProfileService:GetQuestProgress(player, questType)
 	local questList = QuestData[questType]
 	if not questList then return end
 
@@ -81,8 +82,8 @@ claimAllQuestsEvent.OnServerEvent:Connect(function(player, data)
 	for _, quest in ipairs(questList) do
 		local id = quest.id
 		if not progress[id .. "_claimed"] and (progress[id] or 0) >= (quest.goal or 1) then
-			ProfileWrapper:GrantRewards(player, quest.rewards or {}, true)
-			ProfileWrapper:ClaimQuest(player, questType, id)
+                        RewardService.GrantRewards(player, quest.rewards or {}, true)
+                        ProfileService:ClaimQuest(player, questType, id)
 			claimedCount += 1
 			table.insert(claimedList, {
 				Id = id,
@@ -94,7 +95,7 @@ claimAllQuestsEvent.OnServerEvent:Connect(function(player, data)
 
 	questClaimResult:FireClient(player, claimedList)
 
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if profile then
 		ProfileSyncService:Send(player, "QuestProgress", profile.Data.QuestProgress)
 	end
@@ -105,7 +106,7 @@ end)
 
 --// Quests abrufen
 getQuestsFunction.OnServerInvoke = function(player, questType)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("GetPlayerQuests abgelehnt für", player and player.Name)
 		return nil
 	end
@@ -121,7 +122,7 @@ getQuestsFunction.OnServerInvoke = function(player, questType)
 		return nil
 	end
 
-	local progress = ProfileWrapper:GetQuestProgress(player, questType)
+        local progress = ProfileService:GetQuestProgress(player, questType)
 	local result = {}
 
 	for _, quest in ipairs(questList) do

--- a/src/ServerScriptService/Server/ShopServerHandler.server.lua
+++ b/src/ServerScriptService/Server/ShopServerHandler.server.lua
@@ -6,7 +6,8 @@ local MarketplaceService = game:GetService("MarketplaceService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 --// Modules
-local ProfileWrapper = require(game.ServerScriptService.Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(game.ServerScriptService.Modules:WaitForChild("ProfileService"))
+local RewardService = require(game.ServerScriptService.Modules:WaitForChild("RewardService"))
 local PremiumShop = require(ReplicatedStorage.Modules:WaitForChild("PremiumShopModule"))
 local ProfileSyncService = require(game.ServerScriptService.Modules:WaitForChild("ProfileSyncService"))
 
@@ -16,7 +17,7 @@ local GetPurchases = ReplicatedStorage.Remotes.Profile:WaitForChild("GetPurchase
 
 -- Prüfe, ob der Spieler bereits gekauft hat
 	GetPurchases.OnServerInvoke = function(player)
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if profile then
 		return profile.Data.Purchases
 	else
@@ -30,7 +31,7 @@ MarketplaceService.ProcessReceipt = function(receiptInfo)
 	local player = Players:GetPlayerByUserId(receiptInfo.PlayerId)
 	if not player then return Enum.ProductPurchaseDecision.NotProcessedYet end
 
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then return Enum.ProductPurchaseDecision.NotProcessedYet end
 
 	local productId = receiptInfo.ProductId
@@ -62,13 +63,13 @@ MarketplaceService.ProcessReceipt = function(receiptInfo)
 
 	-- Premium-Status aktivieren, wenn BattlepassPremium gekauft wurde
 	if data.productKey == "BattlepassPremium" then
-		ProfileWrapper:SetBattlepassPremium(player, true)
-		ProfileSyncService:Send(player, "Battlepass", ProfileWrapper:GetBattlepass(player))
+                ProfileService:SetBattlepassPremium(player, true)
+                ProfileSyncService:Send(player, "Battlepass", ProfileService:GetBattlepass(player))
 		print("[SHOP] 🎫 Premium-Status sofort aktiviert für", player.Name)
 	end
 
 	-- Belohnung vergeben (falls vorhanden)
-	ProfileWrapper:GrantRewards(player, data.rewards)
+        RewardService.GrantRewards(player, data.rewards)
 
 	print("[SHOP] ✅ Kauf abgeschlossen:", productId, "→", data.productKey)
 	return Enum.ProductPurchaseDecision.PurchaseGranted

--- a/src/ServerScriptService/Server/TeleportStageHandler.server.lua
+++ b/src/ServerScriptService/Server/TeleportStageHandler.server.lua
@@ -9,7 +9,7 @@ local ServerScriptService = game:GetService("ServerScriptService")
 --// Modules
 local MapData = require(ReplicatedStorage.Modules.MapDataModule)
 local MapDataUtils = require(ReplicatedStorage.Modules.MapDataUtils)
-local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrapper)
+local ProfileService = require(ServerScriptService.Modules.ProfileService)
 
 --// Remote
 local remote = ReplicatedStorage.Remotes.Teleport:WaitForChild("TeleportStageRequest")
@@ -41,7 +41,7 @@ remote.OnServerEvent:Connect(function(player: Player, worldName: string, stageId
 	end
 
 	-- Stage im Profil speichern
-	local success = ProfileStoreWrapper:SetSelectedStage(player, worldName, stageId)
+        local success = ProfileService:SetSelectedStage(player, worldName, stageId)
 	if not success then
 		warn("[TeleportStageHandler] ❌ Konnte SelectedStage nicht speichern")
 		return

--- a/src/ServerScriptService/Server/UnitServerHandler.server.lua
+++ b/src/ServerScriptService/Server/UnitServerHandler.server.lua
@@ -7,7 +7,7 @@ local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local UnitData = require(ReplicatedStorage.Modules:WaitForChild("UnitDataModule"))
 
@@ -23,19 +23,19 @@ local ProfileChanged = ReplicatedStorage.Remotes.Profile:WaitForChild("ProfileCh
 
 --// Units für Client abrufen (UUID-System)
 getUnitsFunction.OnServerInvoke = function(player)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("GetPlayerUnits abgelehnt für", player and player.Name)
 		return {}
 	end
 
-	local result = ProfileWrapper:GetUnits(player)
+        local result = ProfileService:GetUnits(player)
 	log("📦 Units gesendet für", player.Name, "(Anzahl:", #result, ")")
 	return result
 end
 
 --// Unit ausrüsten
 equipUnitEvent.OnServerEvent:Connect(function(player, slot, unitUUID)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("EquipUnit abgelehnt – Profil nicht geladen für", player and player.Name)
 		return
 	end
@@ -52,13 +52,13 @@ end
 		return
 	end
 
-	local equipped = ProfileWrapper:EquipUnit(player, slot, unitUUID)
+        local equipped = ProfileService:EquipUnit(player, slot, unitUUID)
 	if equipped then
 		log("🎮 Unit", unitUUID, "auf Slot", slot, "für", player.Name)
 
 		-- 🔧 EquipSlots & LiveSync senden
-		local updated = ProfileWrapper:GetUnits(player)
-		local equippedSlots = ProfileWrapper:GetEquippedUnits(player)
+                local updated = ProfileService:GetUnits(player)
+                local equippedSlots = ProfileService:GetEquippedUnits(player)
 
 		for s = 1, 6 do
 			local uuid = equippedSlots[s]

--- a/src/ServerScriptService/Server/UpgradeServerHandler.server.lua
+++ b/src/ServerScriptService/Server/UpgradeServerHandler.server.lua
@@ -7,7 +7,7 @@ local Players = game:GetService("Players")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 
 --// Debug
@@ -25,18 +25,18 @@ local getUpgradesFunction = ReplicatedStorage.Remotes.Upgrades:WaitForChild("Get
 
 --// Upgrades für Client abrufen (Read-Only)
 getUpgradesFunction.OnServerInvoke = function(player)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("GetPlayerUpgrades abgelehnt für", player and player.Name)
 		return {}
 	end
-	local upgrades = ProfileWrapper:GetUpgrades(player)
+        local upgrades = ProfileService:GetUpgrades(player)
 	log("Upgrades für", player.Name, "abgerufen")
 	return upgrades
 end
 
 --// Inventargröße upgraden
 upgradeInventoryEvent.OnServerEvent:Connect(function(player, newSize)
-	if not ProfileWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warnf("UpgradeInventory abgelehnt (Profil nicht geladen) für", player and player.Name)
 		return
 	end
@@ -49,6 +49,6 @@ upgradeInventoryEvent.OnServerEvent:Connect(function(player, newSize)
 		return
 	end
 
-	ProfileWrapper:UpgradeInventory(player, newSize)
+        ProfileService:UpgradeInventory(player, newSize)
 	log("Inventargröße auf", newSize, "für", player.Name, "gesetzt")
 end)

--- a/src/ServerScriptService/Summoning/SummonServiceModule.lua
+++ b/src/ServerScriptService/Summoning/SummonServiceModule.lua
@@ -12,7 +12,7 @@ local SummonRemotes = ReplicatedStorage:WaitForChild("Remotes"):WaitForChild("Su
 local SummonResult  = SummonRemotes:WaitForChild("SummonResult")
 
 --// Modules (Server)
-local ProfileStoreWrapper = require(ServerScriptService.Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(ServerScriptService.Modules:WaitForChild("ProfileService"))
 local SummonPoolModule    = require(ServerScriptService.Summoning:WaitForChild("SummonPoolModule"))
 
 -- Optional (Server-Schutz)
@@ -65,7 +65,7 @@ end
 
 local function tryConsumeTyped(player, itemType, itemId, amount): boolean
 	-- Nutze die vorhandene API des Wrappers
-	local ok = ProfileStoreWrapper:RemoveItemTyped(player, itemType, itemId, amount, false)
+        local ok = ProfileService:RemoveItemTyped(player, itemType, itemId, amount, false)
 	return ok == true
 end
 
@@ -77,7 +77,7 @@ function SummonServiceModule:ProcessSummon(player, summonType)
 	end
 
 	-- Profil prüfen
-	if not ProfileStoreWrapper:IsLoaded(player) then
+        if not ProfileService:IsLoaded(player) then
 		warn("[SummonService] Profile not ready for", player.Name)
 		return
 	end
@@ -93,7 +93,7 @@ function SummonServiceModule:ProcessSummon(player, summonType)
 	local costType, costId, costAmount = SummonPoolModule:GetCost(summonType)
 	if costType and costId and costAmount and costAmount > 0 then
 		-- Nur getypte Items (Scroll/Token/Material/...) werden hier behandelt
-		local inv = ProfileStoreWrapper:GetInventory(player)
+                local inv = ProfileService:GetInventory(player)
 		local have = getTypedCount(inv, costType, costId)
 
 		if have < costAmount then
@@ -122,9 +122,9 @@ function SummonServiceModule:ProcessSummon(player, summonType)
 
 	-- Units ins Inventar
 	for _, unitId in ipairs(unitIds) do
-		local ok, err = pcall(function()
-			ProfileStoreWrapper:AddUnit(player, unitId)
-		end)
+                local ok, err = pcall(function()
+                        ProfileService:AddUnit(player, unitId)
+                end)
 		if not ok then
 			warn("[SummonService] AddUnit fehlgeschlagen:", unitId, err)
 		end

--- a/src/ServerScriptService/TowerDefense/Combat/DamageSystem.lua
+++ b/src/ServerScriptService/TowerDefense/Combat/DamageSystem.lua
@@ -8,7 +8,8 @@ local Workspace = game:GetService("Workspace")
 local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 
 --// Modules
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
+local RewardService = require(Modules:WaitForChild("RewardService"))
 local CombatStatsProvider = require(ReplicatedStorage.TDModules.Combat.CombatStatsProvider)
 local UnitTargetingModule = require(ReplicatedStorage.TDModules.Combat.UnitTargetingModule)
 local WaveManager = require(game.ServerScriptService.TowerDefense.WaveManager)
@@ -89,10 +90,10 @@ local function beginAttackLoop(towerModel: Model, unitId: string, player: Player
 
 					log(`☠️ {target.Name} wurde getötet von {tuuid}`)
 					target:Destroy()
-					ProfileWrapper:AddTDEclipsium(player, 20)
-					ProfileWrapper:AddBattlepassEXP(player, 5)
-					ProfileWrapper:IncrementUnitKills(player, uuid, 1, true)
-					ProfileWrapper:Sync(player, "TDEclipsium")
+                                        RewardService.AddTDEclipsium(player, 20)
+                                        RewardService.AddBattlepassEXP(player, 5)
+                                        ProfileService:IncrementUnitKills(player, uuid, 1, true)
+                                        ProfileService:Sync(player, "TDEclipsium")
 				end
 			end
 

--- a/src/ServerScriptService/TowerDefense/GetSelectedStageHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/GetSelectedStageHandler.server.lua
@@ -4,12 +4,12 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 -- Modules
-local ProfileWrapper = require(game.ServerScriptService.Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(game.ServerScriptService.Modules:WaitForChild("ProfileService"))
 
 -- Remotes
 local GetSelectedStage = ReplicatedStorage.Remotes.Profile:WaitForChild("GetSelectedStage")
 
 
 GetSelectedStage.OnServerInvoke = function(player)
-	return ProfileWrapper:GetSelectedStage(player)
+        return ProfileService:GetSelectedStage(player)
 end

--- a/src/ServerScriptService/TowerDefense/MatchServerHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/MatchServerHandler.server.lua
@@ -13,7 +13,7 @@ local Modules = ServerScriptService:WaitForChild("Modules")
 local TowerDefense = ServerScriptService:WaitForChild("TowerDefense")
 
 --// Module
-local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
+local ProfileService = require(Modules:WaitForChild("ProfileService"))
 local WaveManager = require(TowerDefense:WaitForChild("WaveManager"))
 local EnemyManager = require(TowerDefense:WaitForChild("EnemyManager"))
 local MatchStateModule = require(TowerDefense:WaitForChild("MatchStateModule"))
@@ -55,7 +55,7 @@ log("✅ MatchServerHandler bereit")
 
 --// Startgeld setzen (Debug oder Tutorial)
 SetTDEclipsium.OnServerEvent:Connect(function(player)
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then return end
 
 	profile.Data.Player.TDEclipsium = 20000
@@ -65,7 +65,7 @@ end)
 --// AutoWave vom Client setzen
 SetAutoWaveEnabled.OnServerEvent:Connect(function(player, enabled: boolean)
 	log("🔁 AutoWave von", player.Name, "→", enabled)
-	ProfileWrapper:SetSetting(player, "AutoWaveEnabled", enabled)
+        ProfileService:SetSetting(player, "AutoWaveEnabled", enabled)
 
 	if matchStarted then
 		WaveManager:SetAutoWaveEnabled(enabled)
@@ -75,7 +75,7 @@ end)
 SetSeamlessEnabled.OnServerEvent:Connect(function(player, enabled: boolean)
 	log("⚙️ SeamlessRestart von", player.Name, "→", enabled)
 	local mode = enabled and "seamless" or "teleport"
-	ProfileWrapper:SetSetting(player, "RestartMode", mode)
+        ProfileService:SetSetting(player, "RestartMode", mode)
 end)
 
 --// Wellenstart (Initial oder Folge-Welle)
@@ -101,13 +101,13 @@ StartWaveRequest.OnServerEvent:Connect(function(player, mode)
 	matchStarted = true
 
 	-- Profil laden
-	local profile = ProfileWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then
 		warn("❌ Kein Profil für", player.Name)
 		return
 	end
 
-	local teleportData = ProfileWrapper:GetSelectedStage(player)
+        local teleportData = ProfileService:GetSelectedStage(player)
 	print("📦 teleportData =", teleportData)
 	if not teleportData or teleportData.MapName == "" or teleportData.StageId <= 0 then
 		warn("❌ Kein gültiger SelectedStage im Profil:", player.Name)
@@ -130,7 +130,7 @@ StartWaveRequest.OnServerEvent:Connect(function(player, mode)
 	log("📦 Wellenplan generiert mit", stage.WaveConfig.WaveCount, "Wellen")
 
 	-- AutoWave synchronisieren
-	local settings = ProfileWrapper:GetSettings(player)
+        local settings = ProfileService:GetSettings(player)
 	WaveManager:SetAutoWaveEnabled(settings.AutoWaveEnabled == true)
 
 	-- Erste Welle starten
@@ -138,7 +138,7 @@ StartWaveRequest.OnServerEvent:Connect(function(player, mode)
 end)
 
 MatchResultAction.OnServerEvent:Connect(function(player, action)
-	local selectedStage = ProfileWrapper:GetSelectedStage(player)
+        local selectedStage = ProfileService:GetSelectedStage(player)
 	local mapName = selectedStage.MapName
 	local stageId = selectedStage.StageId
 
@@ -151,7 +151,7 @@ MatchResultAction.OnServerEvent:Connect(function(player, action)
 		return
 
 	elseif action == "Restart" then
-		local restartMode = ProfileWrapper:GetSettings(player).RestartMode or "teleport"
+                local restartMode = ProfileService:GetSettings(player).RestartMode or "teleport"
 
 		if restartMode == "seamless" then
 			log("🔁 Seamless Restart – Reset MatchState in aktueller Instanz für", player.Name)
@@ -161,7 +161,7 @@ MatchResultAction.OnServerEvent:Connect(function(player, action)
 			EnemyManager:Reset()
 			matchStarted = false
 
-			local profile = ProfileWrapper:GetProfile(player)
+                        local profile = ProfileService:GetProfile(player)
 			if profile then
 				profile.Data.Player.TDEclipsium = nil
 			end
@@ -179,7 +179,7 @@ MatchResultAction.OnServerEvent:Connect(function(player, action)
 		return
 
 	elseif action == "Continue" then
-		local profile = ProfileWrapper:GetProfile(player)
+                local profile = ProfileService:GetProfile(player)
 		if not profile then return end
 
 		if mapName == "" or stageId == 0 then
@@ -191,7 +191,7 @@ MatchResultAction.OnServerEvent:Connect(function(player, action)
 		local mapInfo = MapData[mapName]
 
 		if mapInfo and mapInfo.Stages and mapInfo.Stages[nextStage] then
-			ProfileWrapper:SetSelectedStage(player, mapName, nextStage)
+                        ProfileService:SetSelectedStage(player, mapName, nextStage)
 			StageTeleportService.TeleportToStage(player, mapName, nextStage)
 			return
 		else
@@ -217,7 +217,7 @@ MatchResultAction.OnServerEvent:Connect(function(player, action)
 			local nextStageId = stageInfo.NextStage.StageId
 			log("➡️ NextStage: teleportiere", player.Name, "→", nextMap, "Stage", nextStageId)
 
-			ProfileWrapper:SetSelectedStage(player, nextMap, nextStageId)
+                        ProfileService:SetSelectedStage(player, nextMap, nextStageId)
 			StageTeleportService.TeleportToStage(player, nextMap, nextStageId)
 		else
 			warn("[Next] Kein NextStage definiert für", mapName, "Stage", stageId)

--- a/src/ServerScriptService/TowerDefense/MatchStateModule.lua
+++ b/src/ServerScriptService/TowerDefense/MatchStateModule.lua
@@ -7,7 +7,8 @@ local Workspace = game:GetService("Workspace")
 local Players = game:GetService("Players")
 
 --// Modules
-local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrapper)
+local ProfileService = require(ServerScriptService.Modules.ProfileService)
+local RewardService = require(ServerScriptService.Modules.RewardService)
 
 --// Remotes
 local MatchEndedEvent = ReplicatedStorage.Remotes.TowerDefenseEvents:WaitForChild("MatchEnded")
@@ -59,10 +60,10 @@ function MatchStateModule.EndMatch(resultType: "Victory" | "Defeat")
 
 	for _, player in ipairs(currentPlayers) do
 		if typeof(player) == "Instance" and player:IsA("Player") then
-			local profile = ProfileStoreWrapper:GetProfile(player)
+                        local profile = ProfileService:GetProfile(player)
 			if profile then
 				if resultType == "Victory" and #rewards > 0 then
-					ProfileStoreWrapper:GrantRewards(player, rewards)
+                                        RewardService.GrantRewards(player, rewards)
 					print("🎁 Rewards an", player.Name, "vergeben.")
 				end
 

--- a/src/ServerScriptService/TowerDefense/PlaceTowerHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/PlaceTowerHandler.server.lua
@@ -11,7 +11,7 @@ local HttpService = game:GetService("HttpService")
 local PlaceTowerRequest = ReplicatedStorage.Remotes.TowerDefenseEvents:WaitForChild("PlaceTowerRequest")
 
 --// Module
-local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrapper)
+local ProfileService = require(ServerScriptService.Modules.ProfileService)
 local UnitDataModule = require(ReplicatedStorage.Modules.UnitDataModule)
 local DamageSystem = require(ServerScriptService.TowerDefense.Combat.DamageSystem)
 local UnitStatModule = require(ReplicatedStorage.Modules.UnitStatsModule)
@@ -40,7 +40,7 @@ PlaceTowerRequest.OnServerEvent:Connect(function(player: Player, unitName: strin
 		return
 	end
 
-	local profile = ProfileStoreWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then
 		warn("❌ Kein Profil geladen für", player.Name)
 		return

--- a/src/ServerScriptService/TowerDefense/SellHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/SellHandler.server.lua
@@ -8,7 +8,7 @@ local ServerScriptService = game:GetService("ServerScriptService")
 local Modules = ServerScriptService:WaitForChild("Modules")
 
 --// Modules
-local ProfileStoreWrapper = require(Modules.ProfileStoreWrapper)
+local ProfileService = require(Modules.ProfileService)
 local UnitsDataModule = require(ReplicatedStorage.Modules.UnitDataModule)
 local UpgradeConfig = require(ReplicatedStorage.TDModules.Systems.UpgradeConfig)
 local UnitStatModule = require(ReplicatedStorage.Modules.UnitStatsModule)
@@ -30,7 +30,7 @@ SellTowerRequest.OnServerEvent:Connect(function(player: Player, payload: { tuuid
 	local tuuid = payload.tuuid
 	local uuid = payload.uuid
 
-	local profile = ProfileStoreWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then
 		warn(`[SellHandler] ❌ Kein Profil für Spieler {player.Name} gefunden`)
 		return

--- a/src/ServerScriptService/TowerDefense/TargetingHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/TargetingHandler.server.lua
@@ -8,7 +8,7 @@ local ServerScriptService = game:GetService("ServerScriptService")
 local Modules = ServerScriptService:WaitForChild("Modules")
 
 --// Modules
-local ProfileStoreWrapper = require(Modules.ProfileStoreWrapper)
+local ProfileService = require(Modules.ProfileService)
 
 --// Remote
 local SetTargetingModeRequest = ReplicatedStorage.Remotes.TowerDefenseEvents:WaitForChild("SetTargetingModeRequest")
@@ -22,7 +22,7 @@ SetTargetingModeRequest.OnServerEvent:Connect(function(player: Player, payload: 
 	local tuuid = payload.tuuid
 	local mode = payload.mode
 
-	local profile = ProfileStoreWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then return end
 
 	-- Modell finden

--- a/src/ServerScriptService/TowerDefense/UpgradeHandler.server.lua
+++ b/src/ServerScriptService/TowerDefense/UpgradeHandler.server.lua
@@ -8,7 +8,7 @@ local ServerScriptService   = game:GetService("ServerScriptService")
 local Modules               = ServerScriptService:WaitForChild("Modules")
 
 --// Modules
-local ProfileStoreWrapper = require(Modules.ProfileStoreWrapper)
+local ProfileService = require(Modules.ProfileService)
 local CombatStatsProvider = require(ReplicatedStorage.TDModules.Combat.CombatStatsProvider)
 local UnitsDataModule = require(ReplicatedStorage.Modules.UnitDataModule)
 local UpgradeConfig = require(ReplicatedStorage.TDModules.Systems.UpgradeConfig)
@@ -23,7 +23,7 @@ UpgradeTowerRequest.OnServerEvent:Connect(function(player: Player, payload: { tu
 	local tuuid = payload.tuuid
 	local uuid = payload.uuid -- optional, wird nur für EXP verwendet
 
-	local profile = ProfileStoreWrapper:GetProfile(player)
+        local profile = ProfileService:GetProfile(player)
 	if not profile then return end
 
 	-- Turm-Model per TUUID suchen
@@ -89,7 +89,7 @@ UpgradeTowerRequest.OnServerEvent:Connect(function(player: Player, payload: { tu
 
 	-- Optional: Fortschrift registrieren
 	if uuid then
-		ProfileStoreWrapper:IncrementUnitKills(player, uuid, 0, true) -- für eventuelle Upgrade-Tracker
+                ProfileService:IncrementUnitKills(player, uuid, 0, true) -- für eventuelle Upgrade-Tracker
 	end
 
 	print(`[Upgrade] {player.Name} upgraded {unitId} (Level {newLevel}) für {upgradeCost} TDE`)

--- a/src/ServerScriptService/TowerDefense/WaveManager.lua
+++ b/src/ServerScriptService/TowerDefense/WaveManager.lua
@@ -14,7 +14,7 @@ local NextWaveAvailable = TDRemotes:WaitForChild("NextWaveAvailable")
 
 --// Modules
 local EnemyManager = require(ServerScriptService.TowerDefense.EnemyManager)
-local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrapper)
+local ProfileService = require(ServerScriptService.Modules.ProfileService)
 local MatchStateModule = require(ServerScriptService.TowerDefense.MatchStateModule)
 
 --// Typen
@@ -246,7 +246,7 @@ function WaveManager:StartWave(waveNumber: number?)
 				else
 					log("⏹ AutoWave deaktiviert beim Timeout – Spielerstart erforderlich")
 					for _, player in ipairs(Players:GetPlayers()) do
-						local profile = ProfileStoreWrapper:GetProfile(player)
+                                            local profile = ProfileService:GetProfile(player)
 						if profile then
 							ShowPlayButton:FireClient(player)
 						end


### PR DESCRIPTION
## Summary
- add RewardService and SystemReadyService wrappers for profile reward and system-ready features
- replace direct ProfileStoreWrapper usage across server scripts with new ProfileService-based services

## Testing
- `rojo build default.project.json -o /tmp/test.rbxlx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b2cb49e248333bbbb5b8567e429e1