### PR TITLE
Use DebugLogger instead of prints

### DIFF
--- a/src/ReplicatedStorage/Modules/DebugLogger.lua
+++ b/src/ReplicatedStorage/Modules/DebugLogger.lua
@@ -1,0 +1,25 @@
+-- DebugLogger.lua
+-- Shared debug logging utility
+
+local function new(prefix, enabled)
+    enabled = enabled ~= false
+
+    local function log(...)
+        if enabled then
+            print("[" .. prefix .. "]", ...)
+        end
+    end
+
+    local function warnf(...)
+        if enabled then
+            warn("[" .. prefix .. "]", ...)
+        end
+    end
+
+    return log, warnf
+end
+
+return {
+    new = new,
+}
+

--- a/src/ReplicatedStorage/Modules/PanelManager.lua
+++ b/src/ReplicatedStorage/Modules/PanelManager.lua
@@ -1,7 +1,10 @@
--- PanelManager.lua
 
 --// Services
 local TweenService = game:GetService("TweenService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("PanelManager")
 
 --// Modul
 local PanelManager = {}
@@ -26,21 +29,21 @@ end
 
 -- Panel öffnen (schließt vorheriges automatisch)
 function PanelManager:OpenPanel(panel)
-	if not panel then return end
+        if not panel then return end
 
-	print("PanelManager: OpenPanel für", panel.Name)
+        log("OpenPanel für", panel.Name)
 
 	-- Schließe ggf. vorheriges Panel
 	if self.CurrentlyOpenPanel and self.CurrentlyOpenPanel ~= panel and self.CurrentlyOpenPanel.Visible then
-		print("PanelManager: Schließe vorheriges Panel:", self.CurrentlyOpenPanel.Name)
+                log("Schließe vorheriges Panel:", self.CurrentlyOpenPanel.Name)
 		self:ClosePanel(self.CurrentlyOpenPanel)
 	end
 
 	-- ScreenGui aktivieren
 	local screenGui = panel:FindFirstAncestorWhichIsA("ScreenGui")
 	if screenGui and not screenGui.Enabled then
-		screenGui.Enabled = true
-		print("PanelManager: ScreenGui aktiviert:", screenGui.Name)
+                screenGui.Enabled = true
+                log("ScreenGui aktiviert:", screenGui.Name)
 	end
 
 	-- Panel sichtbar machen
@@ -69,9 +72,9 @@ end
 
 -- Panel schließen (inkl. Fade & Shrink)
 function PanelManager:ClosePanel(panel)
-	if not panel then return end
+        if not panel then return end
 
-	print("PanelManager: ClosePanel für", panel.Name)
+        log("ClosePanel für", panel.Name)
 
 	local originalSize = self.OriginalSizes[panel] or panel.Size
 	local canvasGroup  = panel:FindFirstChildWhichIsA("CanvasGroup")
@@ -108,8 +111,8 @@ function PanelManager:ClosePanel(panel)
 					end
 				end
 				if not anyVisible then
-					screenGui.Enabled = false
-					print("PanelManager: ScreenGui deaktiviert:", screenGui.Name)
+                                        screenGui.Enabled = false
+                                        log("ScreenGui deaktiviert:", screenGui.Name)
 				end
 			end
 		end)
@@ -130,8 +133,8 @@ function PanelManager:ClosePanel(panel)
 				end
 			end
 			if not anyVisible then
-				screenGui.Enabled = false
-				print("PanelManager: ScreenGui deaktiviert:", screenGui.Name)
+                                screenGui.Enabled = false
+                                log("ScreenGui deaktiviert:", screenGui.Name)
 			end
 		end
 	end
@@ -141,7 +144,7 @@ end
 function PanelManager:InstantCloseAll(exceptPanel)
 	for _, panel in ipairs(self.RegisteredPanels) do
 		if panel ~= exceptPanel and panel.Visible then
-			print("PanelManager: InstantClose für", panel.Name)
+                        log("InstantClose für", panel.Name)
 			self:ClosePanel(panel)
 		end
 	end

--- a/src/ServerScriptService/Server/BattlepassServerHandler.server.lua
+++ b/src/ServerScriptService/Server/BattlepassServerHandler.server.lua
@@ -10,6 +10,8 @@ local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local BattlepassInfoProvider = require(ReplicatedStorage.Modules:WaitForChild("BattlepassInfoProvider"))
 BattlepassInfoProvider.Regenerate()
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log, warnf = DebugLogger.new("BattlepassServerHandler")
 
 --// Remotes
 local BattlepassFolder = ReplicatedStorage.Remotes:WaitForChild("Battlepass")
@@ -18,10 +20,6 @@ local ClaimFree = BattlepassFolder:WaitForChild("ClaimFreeRewards")
 local ClaimPremium = BattlepassFolder:WaitForChild("ClaimPremiumRewards")
 
 --// Debug
-local DEBUG = true
-local function log(...)   if DEBUG then print("[BattlepassServerHandler]", ...) end end
-local function warnf(...) if DEBUG then warn("[BattlepassServerHandler]", ...) end end
-
 --// Battlepass Info abrufen
 GetBattlepassInfo.OnServerInvoke = function(player)
 	if not ProfileWrapper:IsLoaded(player) then return nil end

--- a/src/ServerScriptService/Server/CodeRedeemHandler.server.lua
+++ b/src/ServerScriptService/Server/CodeRedeemHandler.server.lua
@@ -10,11 +10,8 @@ local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local CodesDataModule = require(ReplicatedStorage.Modules:WaitForChild("CodeDataModule"))
-
---// Debug
-local DEBUG = true
-local function log(...) if DEBUG then print("[CodeRedeemHandler]", ...) end end
-local function warnf(...) if DEBUG then warn("[CodeRedeemHandler]", ...) end end
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log, warnf = DebugLogger.new("CodeRedeemHandler")
 
 --// Remotes
 local redeemCodeEvent = ReplicatedStorage.Remotes.Codes:WaitForChild("RedeemCode")

--- a/src/ServerScriptService/Server/CollisionGroupSetup.server.lua
+++ b/src/ServerScriptService/Server/CollisionGroupSetup.server.lua
@@ -1,5 +1,9 @@
 -- ServerScriptService/CollisionGroupSetup.server.lua
 local PhysicsService = game:GetService("PhysicsService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("CollisionGroupSetup")
 
 -- Nur selbst erstellbare Gruppen (Default darf nicht enthalten sein!)
 local groups = {
@@ -24,9 +28,9 @@ for _, group in ipairs(groups) do
 		PhysicsService:RegisterCollisionGroup(group)
 	end)
 	if ok then
-		print("✅ Gruppe erstellt:", group)
+                log("✅ Gruppe erstellt:", group)
 	else
-		print("ℹ️  Gruppe bereits vorhanden oder Fehler:", group, err)
+                log("ℹ️  Gruppe bereits vorhanden oder Fehler:", group, err)
 	end
 end
 
@@ -40,7 +44,7 @@ for groupA, rules in pairs(matrix) do
 				PhysicsService:CollisionGroupSetCollidable(groupA, groupB, shouldCollide)
 			end)
 			if ok then
-				print("🔧 Regel gesetzt:", groupA, "<->", groupB, "=", shouldCollide)
+                                log("🔧 Regel gesetzt:", groupA, "<->", groupB, "=", shouldCollide)
 			else
 				warn("⚠️ Fehler bei Regel:", groupA, groupB, err)
 			end
@@ -48,4 +52,4 @@ for groupA, rules in pairs(matrix) do
 	end
 end
 
-print("✅ CollisionGroup Setup abgeschlossen")
+log("✅ CollisionGroup Setup abgeschlossen")

--- a/src/ServerScriptService/Server/InventoryServerHandler.server.lua
+++ b/src/ServerScriptService/Server/InventoryServerHandler.server.lua
@@ -53,8 +53,8 @@ getInventoryFunction.OnServerInvoke = function(player)
 		end
 	end
 
-	print("✅ [GetInventoryData] Sende", #result, "Items an", player.Name)
-	return result
+        log("✅ [GetInventoryData] Sende", #result, "Items an", player.Name)
+        return result
 end
 
 

--- a/src/ServerScriptService/Server/ShopServerHandler.server.lua
+++ b/src/ServerScriptService/Server/ShopServerHandler.server.lua
@@ -5,6 +5,9 @@ local Players = game:GetService("Players")
 local MarketplaceService = game:GetService("MarketplaceService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("ShopServerHandler")
+
 --// Modules
 local ProfileWrapper = require(game.ServerScriptService.Modules:WaitForChild("ProfileStoreWrapper"))
 local PremiumShop = require(ReplicatedStorage.Modules:WaitForChild("PremiumShopModule"))
@@ -62,14 +65,14 @@ MarketplaceService.ProcessReceipt = function(receiptInfo)
 
 	-- Premium-Status aktivieren, wenn BattlepassPremium gekauft wurde
 	if data.productKey == "BattlepassPremium" then
-		ProfileWrapper:SetBattlepassPremium(player, true)
-		ProfileSyncService:Send(player, "Battlepass", ProfileWrapper:GetBattlepass(player))
-		print("[SHOP] 🎫 Premium-Status sofort aktiviert für", player.Name)
+                ProfileWrapper:SetBattlepassPremium(player, true)
+                ProfileSyncService:Send(player, "Battlepass", ProfileWrapper:GetBattlepass(player))
+                log("🎫 Premium-Status sofort aktiviert für", player.Name)
 	end
 
 	-- Belohnung vergeben (falls vorhanden)
 	ProfileWrapper:GrantRewards(player, data.rewards)
 
-	print("[SHOP] ✅ Kauf abgeschlossen:", productId, "→", data.productKey)
+        log("✅ Kauf abgeschlossen:", productId, "→", data.productKey)
 	return Enum.ProductPurchaseDecision.PurchaseGranted
 end

--- a/src/ServerScriptService/Server/TeleportLobbyHandler.server.lua
+++ b/src/ServerScriptService/Server/TeleportLobbyHandler.server.lua
@@ -5,6 +5,9 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players           = game:GetService("Players")
 local Workspace         = game:GetService("Workspace")
 
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("TeleportLobbyHandler")
+
 --// Remotes
 local teleportRemote = ReplicatedStorage.Remotes.Teleport:WaitForChild("TeleportToAreaRequest")
 
@@ -33,6 +36,6 @@ teleportRemote.OnServerEvent:Connect(function(player, areaData)
                 return
         end
 
-        print("[TeleportLobbyHandler] 📦 Teleportiere", player.Name, "nach", areaName)
+        log("📦 Teleportiere", player.Name, "nach", areaName)
         character:PivotTo(target.CFrame + Vector3.new(0, 3, 0))
 end)

--- a/src/ServerScriptService/Server/TeleportPortalHandler.server.lua
+++ b/src/ServerScriptService/Server/TeleportPortalHandler.server.lua
@@ -5,6 +5,9 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players           = game:GetService("Players")
 local Workspace         = game:GetService("Workspace")
 
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("TeleportPortalHandler")
+
 --// Teleport-Ziele
 local portals     = Workspace:WaitForChild("Portals")
 local Summon      = Workspace:WaitForChild("Summon")
@@ -62,14 +65,14 @@ end)
 
 -- TimeoutRemote: Rückteleport zu Story-Lobby
 timeoutRemote.OnServerEvent:Connect(function(player, command)
-	print("🛑 Server: TimeoutRemote empfangen:", player.Name, command)
+        log("🛑 TimeoutRemote empfangen:", player.Name, command)
 
 	if command == "ReturnToLobby" then
 		local backFolder = portals:WaitForChild("BacktoLobby")
 		local destination = backFolder:WaitForChild("BackToStory")
-		local ok = teleportTo(player, destination.CFrame + Vector3.new(0, 3, 0))
-		if ok then
-			print("🔁 Spieler zurückteleportiert (Story):", player.Name)
+                local ok = teleportTo(player, destination.CFrame + Vector3.new(0, 3, 0))
+                if ok then
+                        log("🔁 Spieler zurückteleportiert (Story):", player.Name)
 		else
 			warn("❌ Rückkehrziel oder HumanoidRootPart fehlt (Story).")
 		end
@@ -78,14 +81,14 @@ end)
 
 -- Close Summon → Rückteleport leicht vom Kreis weg
 TeleportBack.OnServerEvent:Connect(function(player, command)
-	print("🛑 Server: TeleportBack empfangen:", player.Name, command)
+        log("🛑 TeleportBack empfangen:", player.Name, command)
 
 	if command == "ReturnToSummon" then
 		local backFolder  = Summon:WaitForChild("BacktoLobby")
 		local destination = backFolder:WaitForChild("BackToSummon")
-		local ok = teleportTo(player, destination.CFrame + Vector3.new(0, 3, 0))
-		if ok then
-			print("🔁 Spieler zurückteleportiert (Summon):", player.Name)
+                local ok = teleportTo(player, destination.CFrame + Vector3.new(0, 3, 0))
+                if ok then
+                        log("🔁 Spieler zurückteleportiert (Summon):", player.Name)
 		else
 			warn("❌ Rückkehrziel oder HumanoidRootPart fehlt (Summon).")
 		end

--- a/src/ServerScriptService/Server/TeleportStageHandler.server.lua
+++ b/src/ServerScriptService/Server/TeleportStageHandler.server.lua
@@ -6,6 +6,9 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local TeleportService = game:GetService("TeleportService")
 local ServerScriptService = game:GetService("ServerScriptService")
 
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log = DebugLogger.new("TeleportStageHandler")
+
 --// Modules
 local MapData = require(ReplicatedStorage.Modules.MapDataModule)
 local MapDataUtils = require(ReplicatedStorage.Modules.MapDataUtils)
@@ -14,17 +17,9 @@ local ProfileStoreWrapper = require(ServerScriptService.Modules.ProfileStoreWrap
 --// Remote
 local remote = ReplicatedStorage.Remotes.Teleport:WaitForChild("TeleportStageRequest")
 
---// Debug Helper
-local DEBUG = true
-local function log(...: any)
-	if DEBUG then
-		print("[TeleportStageHandler]", ...)
-	end
-end
-
 --// Event Handler
 remote.OnServerEvent:Connect(function(player: Player, worldName: string, stageId: number)
-	log("📦 TeleportStageRequest erhalten von", player.Name, "→", worldName, stageId)
+        log("📦 TeleportStageRequest erhalten von", player.Name, "→", worldName, stageId)
 
 	-- Stage validieren
 	local stage = MapDataUtils.GetStageById(worldName, stageId)

--- a/src/ServerScriptService/Server/UnitServerHandler.server.lua
+++ b/src/ServerScriptService/Server/UnitServerHandler.server.lua
@@ -10,11 +10,8 @@ local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
 local UnitData = require(ReplicatedStorage.Modules:WaitForChild("UnitDataModule"))
-
---// Debug
-local DEBUG = true
-local function log(...) if DEBUG then print("[UnitServerHandler]", ...) end end
-local function warnf(...) if DEBUG then warn("[UnitServerHandler]", ...) end end
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log, warnf = DebugLogger.new("UnitServerHandler")
 
 --// Remotes
 local equipUnitEvent = ReplicatedStorage.Remotes.Units:WaitForChild("EquipUnit")

--- a/src/ServerScriptService/Server/UpgradeServerHandler.server.lua
+++ b/src/ServerScriptService/Server/UpgradeServerHandler.server.lua
@@ -9,15 +9,8 @@ local Modules = game:GetService("ServerScriptService"):WaitForChild("Modules")
 --// Modules
 local ProfileWrapper = require(Modules:WaitForChild("ProfileStoreWrapper"))
 local ServerDebounce = require(ReplicatedStorage.Modules:WaitForChild("ServerDebounce"))
-
---// Debug
-local DEBUG = true
-local function log(...)
-	if DEBUG then print("[UpgradeServerHandler]", ...) end
-end
-local function warnf(...)
-	if DEBUG then warn("[UpgradeServerHandler]", ...) end
-end
+local DebugLogger = require(ReplicatedStorage.Modules:WaitForChild("DebugLogger"))
+local log, warnf = DebugLogger.new("UpgradeServerHandler")
 
 --// Remotes
 local upgradeInventoryEvent = ReplicatedStorage.Remotes.Upgrades:WaitForChild("UpgradeInventory")


### PR DESCRIPTION
## Summary
- add DebugLogger to PanelManager
- replace prints with DebugLogger usage in server handlers
- share DebugLogger module in ReplicatedStorage

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b32b6e4408333a5de656b8762d9a0